### PR TITLE
Reverse the order of the change log to keep new stuff on top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changes
 
-* 0.1.0 - Initial release
-* 0.2.0 - Custom configuration
-* 0.3.0 - Focused underlining
-* 0.4.0 - Throttle linting
-* 0.5.0 - New/improved rules, schema for settings
-* 0.6.0 - Improved rules and underlining
-* 0.7.0 - New/improved rules, more details
-* 0.8.0 - Improved rules, shareable config
-* 0.9.0 - Nested .markdownlint.json config
 * 0.10.0 - Ignore comments/TOML, improved rules
+* 0.9.0 - Nested .markdownlint.json config
+* 0.8.0 - Improved rules, shareable config
+* 0.7.0 - New/improved rules, more details
+* 0.6.0 - Improved rules and underlining
+* 0.5.0 - New/improved rules, schema for settings
+* 0.4.0 - Throttle linting
+* 0.3.0 - Focused underlining
+* 0.2.0 - Custom configuration
+* 0.1.0 - Initial release


### PR DESCRIPTION
This is much better at showing what changed from the last time, because as the change log grows, one only has to check the new version as reported by VS Code and the top of the change log instead of scanning down the whole thing, potentially having to scroll once the number of updated grows large enough.