### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -17,6 +17,11 @@ const markdownlintVersion = packageJson
 	.replace(/[^\d.]/, "");
 const configFileName = ".markdownlint.json";
 const markdownLanguageId = "markdown";
+const documentSelector = {
+	"language": markdownLanguageId,
+	"scheme": "file"
+};
+
 const markdownlintRulesMdPrefix = "https://github.com/DavidAnson/markdownlint/blob/v";
 const markdownlintRulesMdPostfix = "/doc/Rules.md";
 const clickForInfo = "Click for more information about ";
@@ -151,7 +156,8 @@ function getConfig (document) {
 // Lints a Markdown document
 function lint (document) {
 	// Skip if not Markdown
-	if (document.languageId !== markdownLanguageId) {
+	if (document.languageId !== markdownLanguageId ||
+		document.uri.scheme !== "file") {
 		return;
 	}
 
@@ -295,7 +301,7 @@ function activate (context) {
 
 	// Register CodeActionsProvider
 	context.subscriptions.push(
-		vscode.languages.registerCodeActionsProvider(markdownLanguageId, {
+		vscode.languages.registerCodeActionsProvider(documentSelector, {
 			"provideCodeActions": provideCodeActions
 		})
 	);


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Markdown, this PR simply updates linting and code actions to be limited to local files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a project using Live Share, and doesn't have this extension installed, then they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the Markdownlint extension installed. Additionally, this wouldn't impact the "local" Markdown development experience.