### PR TITLE
Use document URI as name of checked Markdown string

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -274,9 +274,10 @@ function lint (document) {
 	if (getIgnores().every((ignore) => !ignore.test(normalizedPath))) {
 
 		// Configure
+		const uri = document.uri.toString();
 		const options = {
 			"strings": {
-				"document": document.getText()
+				[uri]: document.getText()
 			},
 			"config": getConfig(document),
 			"customRules": getCustomRules()
@@ -285,8 +286,7 @@ function lint (document) {
 		// Lint and create Diagnostics
 		try {
 			markdownlint
-				.sync(options)
-				.document
+				.sync(options)[uri]
 				// @ts-ignore
 				.forEach((result) => {
 					const ruleName = result.ruleNames[0];


### PR DESCRIPTION
When using the `files` option, markdownlint uses the filepath as name.
Custom rules can use this to change their behavior based on the filename.
This change increases compatibility with such custom rules.

If you are more interested in my use case for this, I am happy to provide further explanations.