### PR TITLE
Add JSONC language mode for .markdownlintrc files

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,15 @@
 		"onCommand:markdownlint.fixLine"
 	],
 	"contributes": {
+		"languages": [
+			{
+				"id": "jsonc",
+				"filenames": [
+					".markdownlint.json",
+					".markdownlintrc"
+				]
+			}
+		],
 		"commands": [
 			{
 				"command": "markdownlint.fixAll",

--- a/package.json
+++ b/package.json
@@ -56,15 +56,6 @@
 		"onCommand:markdownlint.fixLine"
 	],
 	"contributes": {
-		"languages": [
-			{
-				"id": "jsonc",
-				"filenames": [
-					".markdownlint.json",
-					".markdownlintrc"
-				]
-			}
-		],
 		"commands": [
 			{
 				"command": "markdownlint.fixAll",
@@ -83,6 +74,14 @@
 			{
 				"fileMatch": ".markdownlint.json",
 				"url": "./node_modules/markdownlint/schema/markdownlint-config-schema.json"
+			}
+		],
+		"languages": [
+			{
+				"id": "jsonc",
+				"filenames": [
+					".markdownlintrc"
+				]
 			}
 		],
 		"snippets": [


### PR DESCRIPTION
Add JSONC language mode for .markdownlintrc files (markdownlint.json was not changed, see reasons in comments below).