### PR TITLE
Add a yamlValidation contribution point

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,15 @@
 				"url": "./node_modules/markdownlint/schema/markdownlint-config-schema.json"
 			}
 		],
+		"yamlValidation": [
+			{
+				"fileMatch": [
+					".markdownlint.yaml",
+					".markdownlint.yml"
+				],
+				"url": "./node_modules/markdownlint/schema/markdownlint-config-schema.json"
+			}
+		],
 		"languages": [
 			{
 				"id": "jsonc",


### PR DESCRIPTION
The Red Hat YAML extension for VS Code supports a `yamlValidation` [contribution point](https://github.com/redhat-developer/vscode-yaml#language-server-settings) that mirrors `jsonValidation`. The user will see the following with the YAML extension installed:

<img width="741" alt="Screen Shot 2020-11-28 at 11 30 23 AM" src="https://user-images.githubusercontent.com/831617/100523701-bc95d900-316f-11eb-9705-ea4d9c8f334b.png">
