### PR TITLE
Lint visible documents on activation

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -736,10 +736,8 @@ function activate (context) {
 		"dispose": () => suppressLint(throttle.document)
 	});
 
-	// Request (deferred) lint of active document
-	if (vscode.window.activeTextEditor) {
-		requestLint(vscode.window.activeTextEditor.document);
-	}
+	// Lint all visible documents
+	setTimeout(cleanLintVisibleFiles, throttleDuration);
 }
 
 exports.activate = activate;


### PR DESCRIPTION
Changes the extension activation to request linting of all visible documents, not just the active one.

I noticed a small bug while working on the extension where a visible but inactive Markdown file would not be linted until either:

1. A change was made to the document or it was saved.
2. The Output tab was focused. The assumption is that this causes the `onDidChangeVisibleTextEditors` event to fire.


