### PR TITLE
Make markdown in readme use jsonc instead of json

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ For information about authoring custom rules, see [the `markdownlint` documentat
 
 The standard globs used when linting a workspace should match VS Code's default concept of "Markdown files that matter":
 
-```json
+```jsonc
 [
     // Source: https://github.com/microsoft/vscode/blob/main/extensions/markdown-basics/package.json
     "**/*.{md,mkd,mdwn,mdown,markdown,markdn,mdtxt,mdtext,workbook}",


### PR DESCRIPTION
Fixes an issue where the JSON example with comments was highlighted in red. This PR updates it to jsonc to allow comments.