### PR TITLE
Add .markdownlintignore file association

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,14 @@
 		}
 	},
 	"contributes": {
+		"languages": [
+			{
+				"id": "ignore",
+				"filenames": [
+					".markdownlintignore"
+				]
+			}
+		],
 		"commands": [
 			{
 				"command": "markdownlint.fixAll",


### PR DESCRIPTION
This makes sure that .markdownlintignore files are parsed as using ignore syntax.

Fixes #274