### PR TITLE
feat: languages (identifiers) as setting

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -467,11 +467,14 @@ function isMarkdownDocument (document) {
 	const configuration = vscode.workspace.getConfiguration(extensionDisplayName);
 	const configLanguages = configuration.get(sectionLanguages);
 	return (
-		// Document with supported language and URI scheme
+		// Markdown document with supported URI scheme
+		// (Filters out problematic custom schemes like "comment" and "svn")
 		configLanguages.includes(document.languageId) &&
 		schemeSupported.has(document.uri.scheme) &&
 		(
 			// Non-virtual document or document authority matches an open workspace
+			// (Filters out problematic scenarios like source control where vscode
+			// .workspace.fs says documents of any name exist with content "")
 			(document.uri.scheme !== schemeVscodeVfs) ||
 			vscode.workspace.workspaceFolders
 				.filter((folder) => folder.uri.scheme === document.uri.scheme)

--- a/extension.mjs
+++ b/extension.mjs
@@ -984,7 +984,6 @@ export function activate (context) {
 	// Create OutputChannel
 	outputChannel = vscode.window.createOutputChannel(extensionDisplayName);
 	context.subscriptions.push(outputChannel);
-	console.log(extensionDisplayName + " activated with languages: " + configLanguages.join(", ") + ".");
 	outputChannel.appendLine(extensionDisplayName + " activated with languages: " + configLanguages.join(", ") + ".");
 
 	// Get application-level configuration

--- a/extension.mjs
+++ b/extension.mjs
@@ -998,12 +998,7 @@ export function activate (context) {
 	);
 
 	const configuration = vscode.workspace.getConfiguration(extensionDisplayName);
-	let configLanguages = configuration.get(sectionLanguages);
-	if (!vscode.workspace.textDocuments.some(doc => configLanguages.includes(doc.languageId))) {
-		return;
-	}
-	outputChannel.appendLine(extensionDisplayName + " activated with languages: " + configLanguages.join(", ") + ".");
-
+	const configLanguages = configuration.get(sectionLanguages);
 	// Register CodeActionsProvider
 	const documentSelector = configLanguages.map(language => ({ language }));
 	const codeActionProvider = {

--- a/extension.mjs
+++ b/extension.mjs
@@ -976,15 +976,9 @@ function didChangeWorkspaceFolders (changes) {
 }
 
 export function activate (context) {
-	const configuration = vscode.workspace.getConfiguration(extensionDisplayName);
-	let configLanguages = configuration.get(sectionLanguages);
-	if (!vscode.workspace.textDocuments.some(doc => configLanguages.includes(doc.languageId))) {
-		return;
-	}
 	// Create OutputChannel
 	outputChannel = vscode.window.createOutputChannel(extensionDisplayName);
 	context.subscriptions.push(outputChannel);
-	outputChannel.appendLine(extensionDisplayName + " activated with languages: " + configLanguages.join(", ") + ".");
 
 	// Get application-level configuration
 	getApplicationConfiguration();
@@ -1002,6 +996,13 @@ export function activate (context) {
 		vscode.workspace.onDidGrantWorkspaceTrust(didGrantWorkspaceTrust),
 		vscode.workspace.onDidChangeWorkspaceFolders(didChangeWorkspaceFolders)
 	);
+
+	const configuration = vscode.workspace.getConfiguration(extensionDisplayName);
+	let configLanguages = configuration.get(sectionLanguages);
+	if (!vscode.workspace.textDocuments.some(doc => configLanguages.includes(doc.languageId))) {
+		return;
+	}
+	outputChannel.appendLine(extensionDisplayName + " activated with languages: " + configLanguages.join(", ") + ".");
 
 	// Register CodeActionsProvider
 	const documentSelector = configLanguages.map(language => ({ language }));

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
 					"default": {}
 				},
 				"markdownlint.languages": {
-					"description": "Array of language identifiers to lint",
+					"description": "Array of language identifiers for linting. Due to a VSCode limitation, only the 'markdown' language activates the extension.",
 					"scope": "resource",
 					"type": "array",
 					"items": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"multi-root ready"
 	],
 	"activationEvents": [
-		"onLanguage:markdown"
+		"onStartupFinished"
 	],
 	"capabilities": {
 		"untrustedWorkspaces": {
@@ -222,6 +222,17 @@
 					"type": "object",
 					"$ref": "https://raw.githubusercontent.com/DavidAnson/markdownlint/v0.37.4/schema/markdownlint-config-schema.json",
 					"default": {}
+				},
+				"markdownlint.languages": {
+					"description": "Array of language identifiers to lint",
+					"scope": "resource",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"markdown"
+					]
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
 		"multi-root ready"
 	],
 	"activationEvents": [
-		"onLanguage:markdown",
-		"onStartupFinished"
+		"onLanguage:markdown"
 	],
 	"capabilities": {
 		"untrustedWorkspaces": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"multi-root ready"
 	],
 	"activationEvents": [
+		"onLanguage:markdown",
 		"onStartupFinished"
 	],
 	"capabilities": {


### PR DESCRIPTION
Introduce a new configuration setting for specifying an array of language identifiers to lint. This enhancement broadens the "activation" function to include multiple languages, allowing for improved handling of documents beyond just Markdown such as RMarkdown and Quarto without maintenance burden.

Note that language identifiers provided won't trigger the activation of the extension, only the presence of a file with the language identifier being `markdown` will.
The settings will only only linting of any files in a workspace with one `markdown` file.

Fixes partially #228 as extension activation is delegated to other extensions.