### PR TITLE
docs: use `explicit` on code action value instead of `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To automatically fix violations when saving a Markdown document, configure Visua
 
 ```json
 "editor.codeActionsOnSave": {
-    "source.fixAll.markdownlint": true
+    "source.fixAll.markdownlint": "explicit"
 }
 ```
 


### PR DESCRIPTION
## Summary

Documentation:
- Adjust [README example](https://github.com/JamBalaya56562/vscode-markdownlint?tab=readme-ov-file#fix) to show "source.fixAll.markdownlint" configured with "explicit" rather than true in VS Code settings.

## Why?

`true` will be deprecated in favor of "explicit".

<img width="728" height="139" alt="image" src="https://github.com/user-attachments/assets/2d2d0a59-e985-41d4-af62-87635f7a9a54" />

See [the official release notes](https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto) for more information.