### PR TITLE
Fix: use local $ref for bundled markdownlint-config-schema

### DIFF
--- a/markdownlint-cli2-config-schema.json
+++ b/markdownlint-cli2-config-schema.json
@@ -11,7 +11,7 @@
     },
     "config": {
       "description": "markdownlint configuration schema : https://github.com/DavidAnson/markdownlint/blob/v0.40.0/schema/.markdownlint.jsonc",
-      "$ref": "https://raw.githubusercontent.com/DavidAnson/markdownlint/v0.40.0/schema/markdownlint-config-schema.json",
+      "$ref": "markdownlint-config-schema.json",
       "default": {}
     },
     "customRules": {


### PR DESCRIPTION
The bundled `markdownlint-cli2-config-schema.json` references `markdownlint-config-schema.json` via a remote `$ref` URL:

```json
"$ref": "https://raw.githubusercontent.com/DavidAnson/markdownlint/v0.40.0/schema/markdownlint-config-schema.json"
```

Since the referenced schema is already bundled locally in the extension directory, this causes VS Code's JSON language service to report an "untrusted location" warning when `raw.githubusercontent.com` is not in the user's trusted domains.

This PR changes the `$ref` to a relative path pointing to the co-bundled local file, eliminating the warning.

Fixes #423 #422