### PR TITLE
Add category prefix to Command Palette commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,20 +84,24 @@
 	"contributes": {
 		"commands": [
 			{
+				"category": "markdownlint",
 				"command": "markdownlint.fixAll",
-				"title": "Fix all supported markdownlint violations in the document"
+				"title": "Fix all supported violations in the document"
 			},
 			{
+				"category": "markdownlint",
 				"command": "markdownlint.lintWorkspace",
-				"title": "Lint all Markdown files in the workspace with markdownlint"
+				"title": "Lint all Markdown files in the workspace"
 			},
 			{
+				"category": "markdownlint",
 				"command": "markdownlint.openConfigFile",
-				"title": "Create or open the markdownlint configuration file for the workspace"
+				"title": "Create or open the configuration file for the workspace"
 			},
 			{
+				"category": "markdownlint",
 				"command": "markdownlint.toggleLinting",
-				"title": "Toggle linting by markdownlint on/off (temporarily)"
+				"title": "Toggle linting on/off (temporarily)"
 			}
 		],
 		"menus": {


### PR DESCRIPTION
Fixes #438.

This adds a shared `MarkdownLint` category to the extension's contributed commands so VS Code shows them with a consistent Command Palette prefix.

This makes commands easier to rediscover by typing `MarkdownLint`, `mark`, or `ml`, especially for infrequent commands like `markdownlint.toggleLinting`.

No command IDs or command behavior change.

<img width="723" height="148" alt="Screenshot 2026-06-14 at 04 28 58" src="https://github.com/user-attachments/assets/86e21465-4e0b-4c27-8a8d-8735e1ec3561" />
