### PR TITLE
Add markdownlint.fixAllExcludeRules to exclude rules from "Fix all"

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -69,6 +69,7 @@
 			"### markdownlint.severityForError",
 			"### markdownlint.severityForWarning",
 			"### markdownlint.customRules",
+			"### markdownlint.fixAllExcludeRules",
 			"### markdownlint.lintWorkspaceGlobs",
 			"## Suppress",
 			"## Snippets",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changes
 
+* 0.62.0 - Add `fixAllExcludeRules` setting to exclude rules from "Fix all"
 * 0.61.0 - Improved rules, add warnings, add `severityForError`/`Warning`
 * 0.60.0 - Improved rules
 * 0.59.0 - Add `configFile` setting

--- a/README.md
+++ b/README.md
@@ -362,6 +362,22 @@ For information about authoring custom rules, see [the `markdownlint` documentat
 > In `markdownlint-cli2` configuration files, the `modulePaths` property can be used in conjunction to specify one or more additional paths for resolving module references.
 > This can be used to work around the VS Code limitation that globally-installed Node modules are unavailable by setting `modulePaths` to the location of the global module path (typically `/usr/local/lib` on macOS/Linux or `~/AppData/Roaming/npm` on Windows).
 
+### markdownlint.fixAllExcludeRules
+
+This property lists rule names or aliases to exclude from "Fix all" operations: the `markdownlint.fixAll` command, fix-on-save (via `editor.codeActionsOnSave`), and document/selection formatting (see [Fix](#fix) above). Excluded rules are still reported as diagnostics and can still be fixed individually via the light bulb (`Ctrl+.`/`Ctrl+.`/`⌘.`).
+
+This is useful for rules whose automatic fix can remove content that is still being worked on. For example, `MD053`/`link-image-reference-definitions` removes unused link and image reference definitions, which is undesirable while a document is being edited and reference definitions are being added before the links that use them:
+
+```json
+{
+    "markdownlint.fixAllExcludeRules": [
+        "MD053"
+    ]
+}
+```
+
+Both rule names (such as `MD053`) and aliases (such as `link-image-reference-definitions`) are accepted.
+
 ### markdownlint.lintWorkspaceGlobs
 
 This property specifies the list of globs used when linting a workspace with the `markdownlint.lintWorkspace` command.

--- a/extension.mjs
+++ b/extension.mjs
@@ -94,6 +94,7 @@ const openCommand = "vscode.open";
 const sectionConfig = "config";
 const sectionConfigFile = "configFile";
 const sectionCustomRules = "customRules";
+const sectionFixAllExcludeRules = "fixAllExcludeRules";
 const sectionFocusMode = "focusMode";
 const sectionLintWorkspaceGlobs = "lintWorkspaceGlobs";
 const sectionRun = "run";
@@ -418,6 +419,18 @@ function getCustomRules (configuration) {
 	return customRules;
 }
 
+// Returns a Set of lower-case rule names to exclude from "Fix all" operations for the document
+function getFixAllExcludeRules (document) {
+	const configuration = vscode.workspace.getConfiguration(extensionDisplayName, document.uri);
+	const excludeRules = configuration.get(sectionFixAllExcludeRules) || [];
+	return new Set(excludeRules.map((ruleName) => ruleName.toLowerCase()));
+}
+
+// Returns whether any of the rule names is in the set of excluded (lower-case) rule names
+function isRuleExcluded (ruleNames, excludeRules) {
+	return ruleNames.some((ruleName) => excludeRules.has(ruleName.toLowerCase()));
+}
+
 // Gets the value of the optionsDefault parameter to markdownlint-cli2
 async function getOptionsDefault (fs, workspaceConfiguration, config) {
 	return {
@@ -636,9 +649,11 @@ function provideCodeActions (document, range, codeActionContext) {
 	};
 	const diagnostics = codeActionContext.diagnostics || [];
 	const extensionDiagnostics = diagnostics.filter((diagnostic) => diagnostic.source === extensionDisplayName);
+	const excludeRules = getFixAllExcludeRules(document);
 	for (const diagnostic of extensionDiagnostics) {
 		const ruleName = diagnostic.code.value || diagnostic.code;
 		const ruleNameAlias = diagnostic.message.split(":")[0];
+		const excluded = isRuleExcluded(ruleNameAlias.split("/"), excludeRules);
 		if (diagnostic.fixInfo) {
 			// Provide code action to fix the violation
 			const fixTitle = clickToFixThis + ruleNameAlias;
@@ -667,8 +682,8 @@ function provideCodeActions (document, range, codeActionContext) {
 			};
 			addToCodeActions(infoAction);
 		}
-		if (diagnostic.fixInfo) {
-			// Provide code action to fix all similar violations
+		if (diagnostic.fixInfo && !excluded) {
+			// Provide code action to fix all similar violations (unless the rule is excluded from "Fix all")
 			const fixTitle = clickToFixRulePrefix + ruleNameAlias + inTheDocument;
 			const fixAction = new vscode.CodeAction(fixTitle, codeActionKindQuickFix);
 			fixAction.command = {
@@ -754,8 +769,10 @@ function fixAll (ruleNameFilter) {
 				return markdownlintWrapper(document)
 					.then(({ results }) => {
 						const text = document.getText();
-						const errorsToFix =
-							results.filter((error) => (!ruleNameFilter || (error.ruleNames[0] === ruleNameFilter)));
+						const excludeRules = getFixAllExcludeRules(document);
+						const errorsToFix = results.filter((error) =>
+							(!ruleNameFilter || (error.ruleNames[0] === ruleNameFilter)) &&
+							!isRuleExcluded(error.ruleNames, excludeRules));
 						const fixedText = applyFixes(text, errorsToFix);
 						return (text === fixedText) ?
 							null :
@@ -778,9 +795,10 @@ function formatDocument (document, range) {
 		if (isMarkdownDocument(document)) {
 			return markdownlintWrapper(document)
 				.then(({ results }) => {
+					const excludeRules = getFixAllExcludeRules(document);
 					const rangeErrors = results.filter((error) => {
-						const { fixInfo } = error;
-						if (fixInfo) {
+						const { fixInfo, ruleNames } = error;
+						if (fixInfo && !isRuleExcluded(ruleNames, excludeRules)) {
 							// eslint-disable-next-line unicorn/consistent-destructuring
 							const line = error.lineNumber - 1;
 							return ((range.start.line <= line) && (line <= range.end.line));

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "markdownlint",
 	"description": "Markdown linting and style checking for Visual Studio Code",
 	"icon": "images/markdownlint-128.png",
-	"version": "0.61.2",
+	"version": "0.62.0",
 	"author": "David Anson (https://dlaa.me/)",
 	"publisher": "DavidAnson",
 	"sponsor": {
@@ -328,6 +328,15 @@
 				},
 				"markdownlint.customRules": {
 					"description": "Array of paths for custom rules to include when linting.",
+					"scope": "resource",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": []
+				},
+				"markdownlint.fixAllExcludeRules": {
+					"description": "Array of rule names or aliases to exclude from \"Fix all\" operations (the \"fixAll\" command, fix-on-save, and document formatting). Excluded rules are still reported and can be fixed individually.",
 					"scope": "resource",
 					"type": "array",
 					"items": {

--- a/test-ui/tests.cjs
+++ b/test-ui/tests.cjs
@@ -260,6 +260,63 @@ function dynamicWorkspaceSettingsChange () {
 	});
 }
 
+// Exclude a rule from fixAll; verify it is left unfixed while another rule is fixed
+function fixAllExcludeRule () {
+	return testWrapper((resolve, reject, disposables) => {
+		const configuration = vscode.workspace.getConfiguration("markdownlint");
+		let started = false;
+		let fixedAll = false;
+		let done = false;
+		disposables.push(
+			vscode.window.onDidChangeActiveTextEditor((textEditor) => {
+				// eslint-disable-next-line consistent-return
+				callbackWrapper(reject, () => {
+					if (textEditor && !started) {
+						started = true;
+						assert.ok(textEditor.document.uri.path.endsWith("/README.md"));
+						return textEditor.edit((editBuilder) => {
+							// MD019
+							editBuilder.insert(new vscode.Position(0, 1), " ");
+							// MD012
+							editBuilder.insert(new vscode.Position(1, 0), "\n");
+						});
+					}
+				});
+			}),
+			vscode.languages.onDidChangeDiagnostics((diagnosticChangeEvent) => {
+				callbackWrapper(reject, () => {
+					const diagnostics = getDiagnostics(diagnosticChangeEvent, "/README.md");
+					const codes = diagnostics.map((diagnostic) => (diagnostic.code && diagnostic.code.value) || diagnostic.code);
+					if ((codes.length === 2) && !fixedAll) {
+						assert.deepEqual(codes, [ "MD019", "MD012" ]);
+						fixedAll = true;
+						const uri = vscode.Uri.file(path.join(__dirname, "..", "README.md"));
+						vscode.commands.executeCommand("vscode.executeCodeActionProvider", uri, diagnostics[0].range)
+							.then((codeActions) => {
+								const titles = new Set(codeActions.map((codeAction) => codeAction.title));
+								// The excluded rule can still be fixed individually...
+								assert.ok(titles.has("Fix this violation of MD019/no-multiple-space-atx"));
+								// ...but is not offered as a per-rule "Fix all"
+								assert.ok(!titles.has("Fix all violations of MD019/no-multiple-space-atx in the document"));
+								return vscode.commands.executeCommand("markdownlint.fixAll");
+							})
+							.then(noop, reject);
+					} else if ((codes.length === 1) && fixedAll && !done) {
+						// MD012 is fixed; MD019 is excluded from "Fix all" so it remains
+						done = true;
+						assert.deepEqual(codes, [ "MD019" ]);
+						configuration.update("fixAllExcludeRules", undefined, vscode.ConfigurationTarget.Workspace)
+							.then(() => resolve(), reject);
+					}
+				});
+			})
+		);
+		configuration.update("fixAllExcludeRules", [ "MD019" ], vscode.ConfigurationTarget.Workspace)
+			.then(() => vscode.window.showTextDocument(vscode.Uri.file(path.join(__dirname, "..", "README.md"))))
+			.then(noop, reject);
+	});
+}
+
 // Run lintWorkspace command
 function lintWorkspace () {
 	return testWrapper((resolve, reject, disposables) => {
@@ -286,6 +343,7 @@ if (vscode.workspace.workspaceFolders) {
 	tests.push(
 		openEditDiffRevert,
 		dynamicWorkspaceSettingsChange,
+		fixAllExcludeRule,
 		// Run this last because its diagnostics persist after test completion
 		lintWorkspace
 	);


### PR DESCRIPTION
## Summary

Adds a `markdownlint.fixAllExcludeRules` setting (array of rule names or aliases) that excludes the listed rules from **"Fix all"** operations:

- the `markdownlint.fixAll` command,
- fix-on-save (via `editor.codeActionsOnSave`),
- document/selection formatting (`formatDocument`), and
- the per-rule "Fix all violations of `<rule>` in the document" quick fix (which is no longer offered for an excluded rule).

Excluded rules are still reported as diagnostics and can still be fixed **individually** via the "Fix this violation of `<rule>`" light bulb action. In other words, the exclusion is honored by every "fix many at once" path while single-occurrence fixes remain available.

Closes #306.

## Motivation

As raised in #306, some automatic fixes can remove content that is still being worked on. The motivating example is `MD053`/`link-image-reference-definitions`, which deletes unused link/image reference definitions — undesirable while a document is mid-edit and reference definitions are being added before the links that use them. With:

```json
{
    "markdownlint.fixAllExcludeRules": [ "MD053" ]
}
```

`MD053` is still reported but is no longer auto-fixed on save / by `fixAll`, while every other fixable rule continues to be fixed.

## Implementation

- `getFixAllExcludeRules(document)` reads the resource-scoped setting into a lower-cased `Set`; `isRuleExcluded(ruleNames, excludeRules)` matches against a rule's names (so either `MD053` or its alias works).
- `fixAll` filters excluded rules out of the fix in all cases — including when an explicit per-rule filter is supplied — so the per-rule path is a no-op for an excluded rule.
- `formatDocument` filters excluded rules out of the range fixes.
- `provideCodeActions` omits the per-rule "Fix all violations of `<rule>` in the document" action for excluded rules, while still offering "Fix this violation of `<rule>`".

## Changes

- `extension.mjs` — setting reader/predicate + filtering in `fixAll`/`formatDocument` + code-action suppression.
- `package.json` — the `markdownlint.fixAllExcludeRules` configuration contribution.
- `README.md` + `.markdownlint.json` — documents the new setting (new `### markdownlint.fixAllExcludeRules` section, added to `required-headings`).
- `test-ui/tests.cjs` — UI test asserting an excluded rule is left unfixed while another rule is fixed, that its per-rule "Fix all" action is not offered, and that its individual fix action still is.
- `CHANGELOG.md` / `package.json` version — `0.62.0` entry (bumped to keep the metadata consistency test green; adjust as you see fit).

## Testing

- `npm test` — ESLint + markdownlint + 16/16 unit tests + webpack build pass.
- `npm run test-ui` — the `fixAllExcludeRule` test passes in headless and workspace modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
