### PR TITLE
Add markdownlint.lintOutsideWorkspace setting to limit linting to workspace files

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -69,6 +69,7 @@
 			"### markdownlint.severityForError",
 			"### markdownlint.severityForWarning",
 			"### markdownlint.customRules",
+			"### markdownlint.lintOutsideWorkspace",
 			"### markdownlint.lintWorkspaceGlobs",
 			"## Suppress",
 			"## Snippets",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changes
 
+* 0.62.0 - Add `lintOutsideWorkspace` setting to limit linting to workspace files
 * 0.61.0 - Improved rules, add warnings, add `severityForError`/`Warning`
 * 0.60.0 - Improved rules
 * 0.59.0 - Add `configFile` setting

--- a/README.md
+++ b/README.md
@@ -362,6 +362,18 @@ For information about authoring custom rules, see [the `markdownlint` documentat
 > In `markdownlint-cli2` configuration files, the `modulePaths` property can be used in conjunction to specify one or more additional paths for resolving module references.
 > This can be used to work around the VS Code limitation that globally-installed Node modules are unavailable by setting `modulePaths` to the location of the global module path (typically `/usr/local/lib` on macOS/Linux or `~/AppData/Roaming/npm` on Windows).
 
+### markdownlint.lintOutsideWorkspace
+
+By default, `markdownlint` lints every open Markdown document, including files that are not part of the current workspace. Setting this property to `false` restricts linting to files inside an open workspace folder, so Markdown files opened from elsewhere on the file system are not linted:
+
+```json
+{
+    "markdownlint.lintOutsideWorkspace": false
+}
+```
+
+> **Note**: Documents that are not stored on disk (such as untitled documents) are always linted. Explicit actions such as the `markdownlint.fixAll` command and document formatting continue to work regardless of this setting.
+
 ### markdownlint.lintWorkspaceGlobs
 
 This property specifies the list of globs used when linting a workspace with the `markdownlint.lintWorkspace` command.

--- a/extension.mjs
+++ b/extension.mjs
@@ -95,6 +95,7 @@ const sectionConfig = "config";
 const sectionConfigFile = "configFile";
 const sectionCustomRules = "customRules";
 const sectionFocusMode = "focusMode";
+const sectionLintOutsideWorkspace = "lintOutsideWorkspace";
 const sectionLintWorkspaceGlobs = "lintWorkspaceGlobs";
 const sectionRun = "run";
 const sectionSeverityForError = "severityForError";
@@ -560,9 +561,21 @@ function lintWorkspaceViaTask () {
 		});
 }
 
+// Returns whether the document's location should be linted (honors lintOutsideWorkspace)
+function shouldLintDocumentLocation (document) {
+	const configuration = vscode.workspace.getConfiguration(extensionDisplayName, document.uri);
+	if (configuration.get(sectionLintOutsideWorkspace)) {
+		return true;
+	}
+	// Setting is off: only lint files that are inside an open workspace folder
+	// (non-file documents like untitled or virtual are always allowed)
+	return (document.uri.scheme !== schemeFile) ||
+		Boolean(vscode.workspace.getWorkspaceFolder(document.uri));
+}
+
 // Lints a Markdown document
 function lint (document) {
-	if (!lintingEnabled || !isMarkdownDocument(document)) {
+	if (!lintingEnabled || !isMarkdownDocument(document) || !shouldLintDocumentLocation(document)) {
 		return;
 	}
 	const diagnostics = [];
@@ -1015,6 +1028,8 @@ function didChangeWorkspaceFolders (changes) {
 	for (const workspaceFolderUri of changes.added.map((folder) => folder.uri)) {
 		createFileSystemWatchers(workspaceFolderUri);
 	}
+	// Re-lint because workspace membership can affect linting (see "lintOutsideWorkspace")
+	clearDiagnosticsAndLintVisibleFiles();
 }
 
 export function activate (context) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "markdownlint",
 	"description": "Markdown linting and style checking for Visual Studio Code",
 	"icon": "images/markdownlint-128.png",
-	"version": "0.61.2",
+	"version": "0.62.0",
 	"author": "David Anson (https://dlaa.me/)",
 	"publisher": "DavidAnson",
 	"sponsor": {
@@ -343,6 +343,12 @@
 						"integer"
 					],
 					"default": false
+				},
+				"markdownlint.lintOutsideWorkspace": {
+					"description": "Whether to lint Markdown files that are open but not part of the current workspace. Set to false to only lint files within the workspace.",
+					"scope": "resource",
+					"type": "boolean",
+					"default": true
 				},
 				"markdownlint.lintWorkspaceGlobs": {
 					"description": "Array of glob expressions to include or ignore when linting a workspace with the \"lintWorkspace\" command.",

--- a/test-ui/tests.cjs
+++ b/test-ui/tests.cjs
@@ -9,6 +9,7 @@
 
 const assert = require("node:assert");
 const fs = require("node:fs/promises");
+const os = require("node:os");
 const path = require("node:path");
 const vscode = require("vscode");
 
@@ -260,6 +261,49 @@ function dynamicWorkspaceSettingsChange () {
 	});
 }
 
+// Verify lintOutsideWorkspace=false stops linting a file outside the workspace
+function lintOutsideWorkspaceSetting () {
+	return testWrapper((resolve, reject, disposables) => {
+		const configuration = vscode.workspace.getConfiguration("markdownlint");
+		const outsideName = "/markdownlint-outside.md";
+		let fileUri = null;
+		let disabled = false;
+		let done = false;
+		disposables.push(
+			vscode.languages.onDidChangeDiagnostics((diagnosticChangeEvent) => {
+				callbackWrapper(reject, () => {
+					if (!fileUri) {
+						return;
+					}
+					const diagnostics = getDiagnostics(diagnosticChangeEvent, outsideName);
+					const codes = diagnostics.map((diagnostic) => (diagnostic.code && diagnostic.code.value) || diagnostic.code);
+					if ((codes.length > 0) && !disabled) {
+						// By default the outside file is linted
+						assert.ok(codes.includes("MD019"));
+						disabled = true;
+						configuration.update("lintOutsideWorkspace", false, vscode.ConfigurationTarget.Workspace)
+							.then(noop, reject);
+					} else if ((codes.length === 0) && disabled && !done) {
+						// With lintOutsideWorkspace=false the outside file is no longer linted
+						done = true;
+						configuration.update("lintOutsideWorkspace", undefined, vscode.ConfigurationTarget.Workspace)
+							.then(() => vscode.commands.executeCommand("workbench.action.closeActiveEditor"))
+							.then(() => fs.rm(fileUri.fsPath, { "force": true }))
+							.then(() => resolve(), reject);
+					}
+				});
+			})
+		);
+		fs.mkdtemp(path.join(os.tmpdir(), "mdl-"))
+			.then((directory) => {
+				fileUri = vscode.Uri.file(path.join(directory, outsideName));
+				return fs.writeFile(fileUri.fsPath, "#  Heading\n");
+			})
+			.then(() => vscode.window.showTextDocument(fileUri))
+			.then(noop, reject);
+	});
+}
+
 // Run lintWorkspace command
 function lintWorkspace () {
 	return testWrapper((resolve, reject, disposables) => {
@@ -286,6 +330,7 @@ if (vscode.workspace.workspaceFolders) {
 	tests.push(
 		openEditDiffRevert,
 		dynamicWorkspaceSettingsChange,
+		lintOutsideWorkspaceSetting,
 		// Run this last because its diagnostics persist after test completion
 		lintWorkspace
 	);


### PR DESCRIPTION
## Summary

Adds an opt-in `markdownlint.lintOutsideWorkspace` setting (boolean, default `true`). When set to `false`, Markdown files opened from **outside** the current workspace are no longer linted — diagnostics are restricted to files inside an open workspace folder.

The default (`true`) preserves the long-standing behavior of linting every open Markdown document, so this is a non-breaking, opt-in change.

Closes #440.

## Motivation

As described in #440, the extension lints every open Markdown file, which is undesirable for users who frequently open `.md` files from all over the file system while working in a specific project. The reporter explicitly asked for an opt-in way to restrict linting to the workspace, which this setting provides:

```json
{
    "markdownlint.lintOutsideWorkspace": false
}
```

## Behavior

- **Default (`true`)** — unchanged: all open Markdown documents are linted.
- **`false`** — a document is linted only when it is inside an open workspace folder.
  - Documents not stored on disk (e.g. untitled documents) are always linted, regardless of the setting.
  - Explicit actions (`markdownlint.fixAll`, document/selection formatting) continue to work regardless of the setting; only automatic linting/diagnostics are scoped.

## Implementation

- `shouldLintDocumentLocation(document)` returns `true` unless the setting is `false` and the document is an on-disk file (`file` scheme) that is not within any workspace folder (via `vscode.workspace.getWorkspaceFolder`).
- The check is added to the early-return guard in `lint(document)`, so it only affects diagnostics — not the explicit fix/format paths, which call into the linter directly.
- Toggling the setting re-lints visible files via the existing `onDidChangeConfiguration` handling, so diagnostics for outside-workspace files clear immediately when the setting is turned off.
- Because workspace membership now affects linting, `onDidChangeWorkspaceFolders` also clears and re-lints, so diagnostics update correctly when a folder containing an open file is added or removed.

## Changes

- `extension.mjs` — the `shouldLintDocumentLocation` gate + setting constant.
- `package.json` — the `markdownlint.lintOutsideWorkspace` configuration contribution.
- `README.md` + `.markdownlint.json` — documents the new setting (new `### markdownlint.lintOutsideWorkspace` section, added to `required-headings`).
- `test-ui/tests.cjs` — UI test: an outside-workspace file is linted by default, then stops being linted once the setting is set to `false`.
- `CHANGELOG.md` / `package.json` version — `0.62.0` entry (bumped to keep the metadata consistency test green; adjust as you see fit).

## Testing

- `npm test` — ESLint + markdownlint + 16/16 unit tests + webpack build pass.
- `npm run test-ui` — the new `lintOutsideWorkspaceSetting` test passes in headless and workspace modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
