### PR TITLE
README.md: Replaced misleading info about deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ If none of these files exist, a new `.markdownlint.json` containing the default 
 
 > **Note**: Because JavaScript is cached by VS Code after being loaded, edits to `.markdownlint.cjs`/`.markdownlint.mjs`/`.markdownlint-cli2.cjs`/`.markdownlint-cli2.mjs` require a restart of VS Code.
 
-### ~~markdownlint.config~~
+### Migrating from the deprecated `markdownlint.config`
 
-The `markdownlint.config` property has been deprecated; please use a configuration file instead ([as outlined in the Configure section](#configure)).
+The `markdownlint.config` property has been deprecated. Please use the following guideline to migrate your settings to a configuration file ([as outlined above](#configure)).
 
 When `markdownlint.config` is present in workspace context, replacing it can be done by creating a `.markdownlint.json` file in the root of the workspace with the value of the setting as its content. For example, removing this setting from the project's `.vscode/settings.json`:
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ If none of these files exist, a new `.markdownlint.json` containing the default 
 
 ### Migrating from the deprecated `markdownlint.config`
 
-The `markdownlint.config` property has been deprecated. Please use the following guideline to migrate your settings to a configuration file ([as outlined above](#configure)).
+The `markdownlint.config` property has been deprecated. Please use the following guideline to migrate your settings to a configuration file.
 
 When `markdownlint.config` is present in workspace context, replacing it can be done by creating a `.markdownlint.json` file in the root of the workspace with the value of the setting as its content. For example, removing this setting from the project's `.vscode/settings.json`:
 


### PR DESCRIPTION
Hello. 😊

Today, I opened Visual Studio Code's settings page to find this warning.

<img width="682" height="107" alt="UZByJPb8ID" src="https://github.com/user-attachments/assets/12183745-6547-4b1d-8998-63c18716a979" />

So, I quickly dropped everything and began reading the linter's documentation page. However, I skipped the section titled `~~markdownlint.config~~` because its strikethrough decoration as well as its first paragraph gave the false impression that section contains outdated info about ''using'' the deprecated property. I didn't want to use it; I wanted to migrate from it.

<img width="846" height="122" alt="FwzeuFe6lM" src="https://github.com/user-attachments/assets/f8ea1f8a-090a-4241-b115-5abe61c3d9a2" />

After I read everything there was to read, frustrated, I accidentally read the `~~markdownlint.config~~` section. Surprisingly it had the right info!

This PR intends to prevent others from falling into the same trap by performing the following changes:

- Renames the section from `~~markdownlint.config~~` to Migrating from the deprecated `markdownlint.config`
- Changes the first paragraph to indicate that the section contains the desired migration info.

Cheers.